### PR TITLE
Allow hasAMLSearch to be one or more searches

### DIFF
--- a/packages/vc-data/CHANGELOG.md
+++ b/packages/vc-data/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- `AMLPersonV1.hasAMLSearch` can now be a single search or an array searches
+
 ## 0.1.0
 
 - Update to use [@bloomprotocol/vc](https://www.npmjs.com/package/@bloomprotocol/vc) as the backing VC model

--- a/packages/vc-data/package-lock.json
+++ b/packages/vc-data/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bloomprotocol/vc-data",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/vc-data/package.json
+++ b/packages/vc-data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bloomprotocol/vc-data",
   "description": "Data types for verifiable credentials (forked from @affinidi/vc-data)",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Bloom Team <team@bloom.co>",
   "license": "Apache-2.0",
   "respository": "https://github.com/hellobloom/ssi-sdk/tree/main/packages/vc-data",

--- a/packages/vc-data/src/aml/v1.ts
+++ b/packages/vc-data/src/aml/v1.ts
@@ -86,7 +86,7 @@ const getHelperContextEntries = () => {
 type AMLPersonV1Mixin = CreateThing<
   'AMLPerson',
   {
-    hasAMLSearch: AMLSearchV1
+    hasAMLSearch: OneOrMore<AMLSearchV1>
   }
 >
 


### PR DESCRIPTION
## Ultimate Problem
`hasAMLSearch` is limited to a single item, but there are cases where we want a person to have multiple searches

## Solution
- Make `hasAMLSeach` `OneOrMore<AMLSearchV1>`