### PR TITLE
Relax schemas

### DIFF
--- a/packages/vc-data/CHANGELOG.md
+++ b/packages/vc-data/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+- Upgrade to latest [@bloomprotocol/vc](https://www.npmjs.com/package/@bloomprotocol/vc)
+
 ## 0.1.2
 
 - Upgrade to latest [@bloomprotocol/vc](https://www.npmjs.com/package/@bloomprotocol/vc)

--- a/packages/vc-data/package.json
+++ b/packages/vc-data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bloomprotocol/vc-data",
   "description": "Data types for verifiable credentials (forked from @affinidi/vc-data)",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Bloom Team <team@bloom.co>",
   "license": "Apache-2.0",
   "repository": "https://github.com/hellobloom/ssi-sdk/tree/main/packages/vc-data",
@@ -28,7 +28,7 @@
     "analyze": "size-limit --why"
   },
   "dependencies": {
-    "@bloomprotocol/vc": "^0.1.2",
+    "@bloomprotocol/vc": "^0.1.3",
     "@ahryman40k/ts-fhir-types": "^4.0.34",
     "ts-toolbelt": "^9.6.0"
   },

--- a/packages/vc/CHANGELOG.md
+++ b/packages/vc/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.3
+
+- Loosen schema for "type" arrays
+  - Now allows "VerifiableCredential"/"VerifiablePresentation" anywhere in the array instead of enforcing it as the first item
+
 ## 0.1.2
 
 - Improve the `RemoveIndex` utility type

--- a/packages/vc/package.json
+++ b/packages/vc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bloomprotocol/vc",
   "description": "TypeScript types, JSON schemas, and signing and verifying functions for Verifiable Credentials and Presentations.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Bloom Team <team@bloom.co>",
   "license": "Apache-2.0",
   "repository": "https://github.com/hellobloom/ssi-sdk/tree/main/packages/vc",

--- a/packages/vc/src/__tests__/core/vc.test.ts
+++ b/packages/vc/src/__tests__/core/vc.test.ts
@@ -1,0 +1,375 @@
+import Ajv, { ValidateFunction } from 'ajv'
+import addFormats from 'ajv-formats'
+
+import { VCProof, vcProofSchema, VCType, vcTypeSchema } from '../../core'
+
+describe('vcProofSchema', () => {
+  let ajv: Ajv
+  let validate: ValidateFunction<VCProof>
+
+  beforeAll(() => {
+    ajv = addFormats(new Ajv())
+    ajv.addSchema(vcProofSchema, 'vcProofSchema')
+  })
+
+  beforeEach(() => {
+    validate = ajv.getSchema('vcProofSchema')!
+  })
+
+  test('valiates a valid VC Proof', () => {
+    const value: VCProof = {
+      type: 'EcdsaSecp256k1Signature2019',
+      created: '2021-06-03T00:00:00Z',
+      proofPurpose: 'assertionMethod',
+      verificationMethod: 'did:example:issuer#123',
+      jws: 'jws',
+    }
+
+    expect(validate(value)).toBeTruthy()
+  })
+
+  describe('fails an invalid VC Proof:', () => {
+    test('missing type', () => {
+      const value = {
+        created: '2021-06-03T00:00:00Z',
+        proofPurpose: 'assertionMethod',
+        verificationMethod: 'did:example:issuer#123',
+        jws: 'jws',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'type'",
+            "params": Object {
+              "missingProperty": "type",
+            },
+            "schemaPath": "#/oneOf/0/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'type'",
+            "params": Object {
+              "missingProperty": "type",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+
+    test('missing created', () => {
+      const value = {
+        type: 'EcdsaSecp256k1Signature2019',
+        proofPurpose: 'assertionMethod',
+        verificationMethod: 'did:example:issuer#123',
+        jws: 'jws',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'created'",
+            "params": Object {
+              "missingProperty": "created",
+            },
+            "schemaPath": "#/oneOf/0/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'created'",
+            "params": Object {
+              "missingProperty": "created",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+
+    test('missing proofPurpose', () => {
+      const value = {
+        type: 'EcdsaSecp256k1Signature2019',
+        created: '2021-06-03T00:00:00Z',
+        verificationMethod: 'did:example:issuer#123',
+        jws: 'jws',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'proofPurpose'",
+            "params": Object {
+              "missingProperty": "proofPurpose",
+            },
+            "schemaPath": "#/oneOf/0/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'proofPurpose'",
+            "params": Object {
+              "missingProperty": "proofPurpose",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+
+    test('invalid proofPurpose', () => {
+      const value = {
+        type: 'EcdsaSecp256k1Signature2019',
+        created: '2021-06-03T00:00:00Z',
+        proofPurpose: 'authentication',
+        verificationMethod: 'did:example:issuer#123',
+        jws: 'jws',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "/proofPurpose",
+            "keyword": "const",
+            "message": "must be equal to constant",
+            "params": Object {
+              "allowedValue": "assertionMethod",
+            },
+            "schemaPath": "#/oneOf/0/properties/proofPurpose/const",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'proofValue'",
+            "params": Object {
+              "missingProperty": "proofValue",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+
+    test('missing verificationMethod', () => {
+      const value = {
+        type: 'EcdsaSecp256k1Signature2019',
+        created: '2021-06-03T00:00:00Z',
+        proofPurpose: 'assertionMethod',
+        jws: 'jws',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'verificationMethod'",
+            "params": Object {
+              "missingProperty": "verificationMethod",
+            },
+            "schemaPath": "#/oneOf/0/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'verificationMethod'",
+            "params": Object {
+              "missingProperty": "verificationMethod",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+
+    test('missing jws', () => {
+      const value = {
+        type: 'EcdsaSecp256k1Signature2019',
+        created: '2021-06-03T00:00:00Z',
+        proofPurpose: 'assertionMethod',
+        verificationMethod: 'did:example:issuer#123',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'jws'",
+            "params": Object {
+              "missingProperty": "jws",
+            },
+            "schemaPath": "#/oneOf/0/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'proofValue'",
+            "params": Object {
+              "missingProperty": "proofValue",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+  })
+})
+
+describe('vcTypeSchema', () => {
+  let ajv: Ajv
+  let validate: ValidateFunction<VCType>
+
+  beforeAll(() => {
+    ajv = addFormats(new Ajv())
+    ajv.addSchema(vcTypeSchema, 'vcTypeSchema')
+  })
+
+  beforeEach(() => {
+    validate = ajv.getSchema('vcTypeSchema')!
+  })
+
+  describe('valiates a valid VC Type:', () => {
+    test('single item', () => {
+      const value: VCType = ['VerifiableCredential']
+
+      expect(validate(value)).toBeTruthy()
+    })
+
+    test('multiple item', () => {
+      const value: VCType = ['VerifiableCredential', 'CustomCredential']
+
+      expect(validate(value)).toBeTruthy()
+    })
+
+    test('multiple item with different order', () => {
+      const value: VCType = ['CustomCredential', 'VerifiableCredential']
+
+      expect(validate(value)).toBeTruthy()
+    })
+  })
+
+  describe('fails an invalid VC Type:', () => {
+    test('empty array', () => {
+      const value: string[] = []
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "minItems",
+            "message": "must NOT have fewer than 1 items",
+            "params": Object {
+              "limit": 1,
+            },
+            "schemaPath": "#/minItems",
+          },
+        ]
+      `)
+    })
+
+    test('missing VerifiableCredential', () => {
+      const value: string[] = ['CustomCredential']
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "contains",
+            "message": "must contain at least 1 valid item(s)",
+            "params": Object {
+              "minContains": 1,
+            },
+            "schemaPath": "#/contains",
+          },
+        ]
+      `)
+    })
+  })
+})

--- a/packages/vc/src/__tests__/core/vp.test.ts
+++ b/packages/vc/src/__tests__/core/vp.test.ts
@@ -1,0 +1,481 @@
+import Ajv, { ValidateFunction } from 'ajv'
+import addFormats from 'ajv-formats'
+
+import { VPProof, vpProofSchema, VPType, vpTypeSchema } from '../../core'
+
+describe('vpProofSchema', () => {
+  let ajv: Ajv
+  let validate: ValidateFunction<VPProof>
+
+  beforeAll(() => {
+    ajv = addFormats(new Ajv())
+    ajv.addSchema(vpProofSchema, 'vpProofSchema')
+  })
+
+  beforeEach(() => {
+    validate = ajv.getSchema('vpProofSchema')!
+  })
+
+  test('valiates a valid VP Proof', () => {
+    const value: VPProof = {
+      type: 'EcdsaSecp256k1Signature2019',
+      created: '2021-06-03T00:00:00Z',
+      proofPurpose: 'authentication',
+      verificationMethod: 'did:example:issuer#123',
+      jws: 'jws',
+      challenge: 'challenge',
+      domain: 'domain',
+    }
+
+    expect(validate(value)).toBeTruthy()
+  })
+
+  describe('fails an invalid VP Proof:', () => {
+    test('missing type', () => {
+      const value = {
+        created: '2021-06-03T00:00:00Z',
+        proofPurpose: 'authentication',
+        verificationMethod: 'did:example:issuer#123',
+        jws: 'jws',
+        challenge: 'challenge',
+        domain: 'domain',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'type'",
+            "params": Object {
+              "missingProperty": "type",
+            },
+            "schemaPath": "#/oneOf/0/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'type'",
+            "params": Object {
+              "missingProperty": "type",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+
+    test('missing created', () => {
+      const value = {
+        type: 'EcdsaSecp256k1Signature2019',
+        proofPurpose: 'authentication',
+        verificationMethod: 'did:example:issuer#123',
+        jws: 'jws',
+        challenge: 'challenge',
+        domain: 'domain',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'created'",
+            "params": Object {
+              "missingProperty": "created",
+            },
+            "schemaPath": "#/oneOf/0/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'created'",
+            "params": Object {
+              "missingProperty": "created",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+
+    test('missing proofPurpose', () => {
+      const value = {
+        type: 'EcdsaSecp256k1Signature2019',
+        created: '2021-06-03T00:00:00Z',
+        verificationMethod: 'did:example:issuer#123',
+        jws: 'jws',
+        challenge: 'challenge',
+        domain: 'domain',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'proofPurpose'",
+            "params": Object {
+              "missingProperty": "proofPurpose",
+            },
+            "schemaPath": "#/oneOf/0/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'proofPurpose'",
+            "params": Object {
+              "missingProperty": "proofPurpose",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+
+    test('invalid proofPurpose', () => {
+      const value = {
+        type: 'EcdsaSecp256k1Signature2019',
+        created: '2021-06-03T00:00:00Z',
+        proofPurpose: 'assertionMethod',
+        verificationMethod: 'did:example:issuer#123',
+        jws: 'jws',
+        challenge: 'challenge',
+        domain: 'domain',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "/proofPurpose",
+            "keyword": "const",
+            "message": "must be equal to constant",
+            "params": Object {
+              "allowedValue": "authentication",
+            },
+            "schemaPath": "#/oneOf/0/properties/proofPurpose/const",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'proofValue'",
+            "params": Object {
+              "missingProperty": "proofValue",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+
+    test('missing verificationMethod', () => {
+      const value = {
+        type: 'EcdsaSecp256k1Signature2019',
+        created: '2021-06-03T00:00:00Z',
+        proofPurpose: 'authentication',
+        jws: 'jws',
+        challenge: 'challenge',
+        domain: 'domain',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'verificationMethod'",
+            "params": Object {
+              "missingProperty": "verificationMethod",
+            },
+            "schemaPath": "#/oneOf/0/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'verificationMethod'",
+            "params": Object {
+              "missingProperty": "verificationMethod",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+
+    test('missing jws', () => {
+      const value = {
+        type: 'EcdsaSecp256k1Signature2019',
+        created: '2021-06-03T00:00:00Z',
+        proofPurpose: 'authentication',
+        verificationMethod: 'did:example:issuer#123',
+        challenge: 'challenge',
+        domain: 'domain',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'jws'",
+            "params": Object {
+              "missingProperty": "jws",
+            },
+            "schemaPath": "#/oneOf/0/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'proofValue'",
+            "params": Object {
+              "missingProperty": "proofValue",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+
+    test('missing challenge', () => {
+      const value = {
+        type: 'EcdsaSecp256k1Signature2019',
+        created: '2021-06-03T00:00:00Z',
+        proofPurpose: 'authentication',
+        verificationMethod: 'did:example:issuer#123',
+        jws: 'jws',
+        domain: 'domain',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'challenge'",
+            "params": Object {
+              "missingProperty": "challenge",
+            },
+            "schemaPath": "#/oneOf/0/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'challenge'",
+            "params": Object {
+              "missingProperty": "challenge",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+
+    test('missing domain', () => {
+      const value = {
+        type: 'EcdsaSecp256k1Signature2019',
+        created: '2021-06-03T00:00:00Z',
+        proofPurpose: 'authentication',
+        verificationMethod: 'did:example:issuer#123',
+        jws: 'jws',
+        challenge: 'challenge',
+      }
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'domain'",
+            "params": Object {
+              "missingProperty": "domain",
+            },
+            "schemaPath": "#/oneOf/0/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "required",
+            "message": "must have required property 'domain'",
+            "params": Object {
+              "missingProperty": "domain",
+            },
+            "schemaPath": "#/oneOf/1/required",
+          },
+          Object {
+            "instancePath": "",
+            "keyword": "oneOf",
+            "message": "must match exactly one schema in oneOf",
+            "params": Object {
+              "passingSchemas": null,
+            },
+            "schemaPath": "#/oneOf",
+          },
+        ]
+      `)
+    })
+  })
+})
+
+describe('VPTypeSchema', () => {
+  let ajv: Ajv
+  let validate: ValidateFunction<VPType>
+
+  beforeAll(() => {
+    ajv = addFormats(new Ajv())
+    ajv.addSchema(vpTypeSchema, 'vpTypeSchema')
+  })
+
+  beforeEach(() => {
+    validate = ajv.getSchema('vpTypeSchema')!
+  })
+
+  describe('valiates a valid VP Type:', () => {
+    test('single item', () => {
+      const value: VPType = ['VerifiablePresentation']
+
+      expect(validate(value)).toBeTruthy()
+    })
+
+    test('multiple item', () => {
+      const value: VPType = ['VerifiablePresentation', 'CustomPresentation']
+
+      expect(validate(value)).toBeTruthy()
+    })
+
+    test('multiple item with different order', () => {
+      const value: VPType = ['CustomPresentation', 'VerifiablePresentation']
+
+      expect(validate(value)).toBeTruthy()
+    })
+  })
+
+  describe('fails an invalid VP Type:', () => {
+    test('empty array', () => {
+      const value: string[] = []
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "minItems",
+            "message": "must NOT have fewer than 1 items",
+            "params": Object {
+              "limit": 1,
+            },
+            "schemaPath": "#/minItems",
+          },
+        ]
+      `)
+    })
+
+    test('missing VerifiablePresentation', () => {
+      const value: string[] = ['CustomPresentation']
+
+      const result = validate(value)
+
+      expect(result).toBeFalsy()
+      expect(validate.errors).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "instancePath": "",
+            "keyword": "contains",
+            "message": "must contain at least 1 valid item(s)",
+            "params": Object {
+              "minContains": 1,
+            },
+            "schemaPath": "#/contains",
+          },
+        ]
+      `)
+    })
+  })
+})

--- a/packages/vc/src/__tests__/sign.test.ts
+++ b/packages/vc/src/__tests__/sign.test.ts
@@ -43,8 +43,6 @@ describe('signVC', () => {
         suite,
       })
 
-      console.log({ proof: signed.proof })
-
       expect(validate(signed)).toBeTruthy()
       expectType<VC>(signed)
     })

--- a/packages/vc/src/__tests__/verify.test.ts
+++ b/packages/vc/src/__tests__/verify.test.ts
@@ -115,7 +115,7 @@ describe('verifyVC', () => {
           const invalid = await signVC({
             unsigned: {
               ...unsignedVC,
-              type: ['UniversityDegreeCredential', 'VerifiableCredential'],
+              type: 'VerifiableCredential',
             } as any,
             documentLoader,
             suite,
@@ -134,13 +134,13 @@ describe('verifyVC', () => {
             expect(result.schemaErrors).toMatchInlineSnapshot(`
               Array [
                 Object {
-                  "instancePath": "/type/0",
-                  "keyword": "const",
-                  "message": "must be equal to constant",
+                  "instancePath": "/type",
+                  "keyword": "type",
+                  "message": "must be array",
                   "params": Object {
-                    "allowedValue": "VerifiableCredential",
+                    "type": "array",
                   },
-                  "schemaPath": "#/properties/type/items/0/const",
+                  "schemaPath": "#/properties/type/type",
                 },
               ]
             `)

--- a/packages/vc/src/core/vc.ts
+++ b/packages/vc/src/core/vc.ts
@@ -43,8 +43,8 @@ export type VCProof = FromSchema<typeof vcProofSchema>
 
 export const vcTypeSchema = {
   type: 'array',
-  items: [{ const: 'VerifiableCredential' }],
-  additionalItems: { type: 'string' },
+  items: { type: 'string' },
+  contains: { const: 'VerifiableCredential' },
   minItems: 1,
 } as const
 

--- a/packages/vc/src/core/vp.ts
+++ b/packages/vc/src/core/vp.ts
@@ -38,8 +38,8 @@ export type VPProof = FromSchema<typeof vpProofSchema>
 
 export const vpTypeSchema = {
   type: 'array',
-  items: [{ const: 'VerifiablePresentation' }],
-  additionalItems: { type: 'string' },
+  items: { type: 'string' },
+  contains: { const: 'VerifiablePresentation' },
   minItems: 1,
 } as const
 


### PR DESCRIPTION
## Ultimate Problem
The VC and VP type schemas enforced that the first item in the array was "VerifiableCredential"/"VerifiablePresentation" but the VC Data Model spec says this is an unordered list

## Solution
- Relax the type schemas

## Notes
- With this the TS type is just `string[]` but it still validates correctly in the verifyVP/verifyVC functions