### PR TITLE
Allow custom hrefs

### DIFF
--- a/packages/waci-kit-react/CHANGELOG.md
+++ b/packages/waci-kit-react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- Add "private" and non-stable `__hrefBuilder` prop to `ButtonOptions`
+
 ## 0.1.1
 
 - Switch to `yarn` and add `resolutions` to package.json for some build dependencies

--- a/packages/waci-kit-react/package.json
+++ b/packages/waci-kit-react/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.1",
+  "version": "0.1.2",
   "name": "@bloomprotocol/waci-kit-react",
   "description": "Render a QR Code or button to initiate a WACI interaction",
   "author": "Bloom Team <team@bloom.co>",

--- a/packages/waci-kit-react/src/button/index.tsx
+++ b/packages/waci-kit-react/src/button/index.tsx
@@ -28,12 +28,17 @@ export const WACIButtonElement: FC<'a', WACIButtonElementProps> = ({ data, ...pr
       throw new Error(`Unknown size: ${(props as any).size}`)
   }
 
+  const href =
+    typeof props.__hrefBuilder === 'undefined'
+      ? `https://bloom.co/download?payload=${window.btoa(JSON.stringify(data))}`
+      : props.__hrefBuilder(data)
+
   return (
     <a
-      {...forwardProps(props, 'size', 'type', 'invert', 'ref')}
+      {...forwardProps(props, 'size', 'type', 'invert', '__hrefBuilder', 'ref')}
       target="_blank"
       rel="noreferrer noopener"
-      href={`https://bloom.co/download?payload=${window.btoa(JSON.stringify(data))}`}
+      href={href}
       id={id}
     >
       {children}

--- a/packages/waci-kit-react/src/types.ts
+++ b/packages/waci-kit-react/src/types.ts
@@ -15,18 +15,22 @@ export type LargeButtonType = 'log-in' | 'sign-up' | 'connect' | 'bloom' | 'veri
 
 export type ButtonSize = 'sm' | 'md' | 'lg'
 
-export type SmallButtonOptions = {
+type BaseButtonOptions = {
+  __hrefBuilder?: (data: CommonWACIElementProps['data']) => string
+}
+
+export type SmallButtonOptions = BaseButtonOptions & {
   size: 'sm'
   type: SmallButtonType
   invert?: boolean
 }
 
-export type MediumButtonOptions = {
+export type MediumButtonOptions = BaseButtonOptions & {
   size: 'md'
   type: MediumButtonType
 }
 
-export type LargeButtonOptions = {
+export type LargeButtonOptions = BaseButtonOptions & {
   size: 'lg'
   type: LargeButtonType
 }


### PR DESCRIPTION
## Ultimate Problem
There may be times where a custom href is needed.

## Solution
- Add a "private" and non-stable prop to `ButtonOptions` that allows a custom `href` to be set