### PR TITLE
fix(ESM): prevent require in module error with ESM build

### DIFF
--- a/packages/ecdsa-secp256k1-signature-2019/src/index.ts
+++ b/packages/ecdsa-secp256k1-signature-2019/src/index.ts
@@ -1,9 +1,12 @@
+// @ts-nocheck
 import { EcdsaSecp256k1VerificationKey2019 } from '@bloomprotocol/ecdsa-secp256k1-verification-key-2019'
 
 import { context } from './context'
 
-const jsonld = require('jsonld')
-const jsigs = require('jsonld-signatures')
+// @ts-expect-error: implicit type import; not a ts package
+import jsonld from 'jsonld'
+// @ts-expect-error: implicit type import; not a ts package
+import jsigs from 'jsonld-signatures'
 
 const SUITE_CONTEXT_URL = 'https://ns.did.ai/suites/secp256k1-2019/v1'
 

--- a/packages/ecdsa-secp256k1-signature-2019/src/index.ts
+++ b/packages/ecdsa-secp256k1-signature-2019/src/index.ts
@@ -1,12 +1,10 @@
 // @ts-nocheck
 import { EcdsaSecp256k1VerificationKey2019 } from '@bloomprotocol/ecdsa-secp256k1-verification-key-2019'
-
-import { context } from './context'
-
 // @ts-expect-error: implicit type import; not a ts package
 import jsonld from 'jsonld'
 // @ts-expect-error: implicit type import; not a ts package
 import jsigs from 'jsonld-signatures'
+import { context } from './context'
 
 const SUITE_CONTEXT_URL = 'https://ns.did.ai/suites/secp256k1-2019/v1'
 

--- a/packages/ecdsa-secp256k1-verification-key-2019/src/keyUtils.ts
+++ b/packages/ecdsa-secp256k1-verification-key-2019/src/keyUtils.ts
@@ -1,7 +1,8 @@
 import secp256k1 from 'secp256k1'
-
-const keyto = require('@trust/keyto')
-const base58 = require('base58-universal')
+// @ts-expect-error: implicit type import; not a ts package
+import keyto from '@trust/keyto'
+// @ts-expect-error: implicit type import; not a ts package
+import * as base58 from 'base58-universal'
 
 const compressedHexEncodedPublicKeyLength = 66
 

--- a/packages/ecdsa-secp256k1-verification-key-2019/src/verificationKey.ts
+++ b/packages/ecdsa-secp256k1-verification-key-2019/src/verificationKey.ts
@@ -1,10 +1,12 @@
+// @ts-nocheck
 import base64url from 'base64url'
 import createHash from 'create-hash'
 import * as secp256k1 from 'secp256k1'
 import randomBytes from 'randombytes'
-
-const cryptoLd = require('crypto-ld')
-const base58 = require('base58-universal')
+// @ts-expect-error: implicit type import; not a ts package
+import cryptoLd from 'crypto-ld'
+// @ts-expect-error: implicit type import; not a ts package
+import * as base58 from 'base58-universal'
 
 const SUITE_ID = 'EcdsaSecp256k1VerificationKey2019'
 

--- a/packages/ecdsa-secp256k1-verification-key-2019/src/verificationKey.ts
+++ b/packages/ecdsa-secp256k1-verification-key-2019/src/verificationKey.ts
@@ -213,7 +213,7 @@ export class EcdsaSecp256k1VerificationKey2019 extends cryptoLd.LDKeyPair {
             digest,
             base58.decode(publicKeyBase58),
           )
-        } catch {
+        } catch (e) {
           verified = false
         }
 


### PR DESCRIPTION
Found this issue while compiling in my own project.
Since it was `require` in the source code, the transpiled version would maintain `require` in the ESM bundle, which would in turn make an actual ESM consumption invalid.

This is what's in the transpiled ESM code:
```
const cryptoLd = /*#__PURE__*/require('crypto-ld');

const base58 = /*#__PURE__*/require('base58-universal');
```

This is the error: 
```

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/julien/work/cert-verifier-js/node_modules/crypto-ld/lib/index.js from /Users/julien/work/cert-verifier-js/dist/verifier-node.js not supported.
Instead change the require of index.js in /Users/julien/work/cert-verifier-js/dist/verifier-node.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/julien/work/cert-verifier-js/dist/verifier-node.js:187558:31)
    at Object.<anonymous> (/Users/julien/work/cert-verifier-js/test/manual-testing/node/server.js:3:24) {
  code: 'ERR_REQUIRE_ESM'
}
```